### PR TITLE
Fix JS error on window resize

### DIFF
--- a/source/colResizable-1.5.source.js
+++ b/source/colResizable-1.5.source.js
@@ -21,7 +21,7 @@
 	var d = $(document); 		//window object
 	var h = $("head");			//head object
 	var drag = null;			//reference to the current grip that is being dragged
-	var tables = [];			//array of the already processed tables (table.id as key)
+	var tables = {};			//object of the already processed tables (table.id as key)
 	var	count = 0;				//internal count to create unique IDs when needed.	
 	
 	//common strings for packing


### PR DESCRIPTION
Iterating with `for (el in arr)` through javascript array iterates
over all properties, what causes error, because not every property
is a table. Change to a javascript object fixes this.

More information about that: http://stackoverflow.com/questions/3010840/loop-through-array-in-javascript

I've got an error on every browser's window resize.