### PR TITLE
Preserve original column widths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,11 @@ ___
 * **marginRight**: [type: string / null] [default: null] [version: 1.3] 
 
 It behaves in exactly the same way than the previous attribute but applied to the right margin.
+___
+
+* **keepOriginalColumnWidths**: [type: boolean] [default: false] [version: 1.3] 
+
+If set to true, it gives the ability to keep the original column widths of the table.
  
 ## Events
 

--- a/source/colResizable-1.5.source.js
+++ b/source/colResizable-1.5.source.js
@@ -38,7 +38,7 @@
 	try{S = sessionStorage;}catch(e){}	//Firefox crashes when executed as local file system
 	
 	//append required CSS rules  
-	h.append("<style type='text/css'>  .JColResizer{table-layout:fixed;} .JColResizer td, .JColResizer th{overflow:hidden;padding-left:0!important; padding-right:0!important;}  .JCLRgrips{ height:0px; position:relative;} .JCLRgrip{margin-left:-5px; position:absolute; z-index:5; } .JCLRgrip .JColResizer{position:absolute;background-color:red;filter:alpha(opacity=1);opacity:0;width:10px;height:100%;cursor: e-resize;top:0px} .JCLRLastGrip{position:absolute; width:1px; } .JCLRgripDrag{ border-left:1px dotted black;	} .JCLRFlex{width:auto!important;}</style>");
+	h.append("<style type='text/css'>  .JColResizer{table-layout:fixed;} .JColResizer td, .JColResizer th{overflow:hidden;}  .JCLRgrips{ height:0px; position:relative;} .JCLRgrip{margin-left:-5px; position:absolute; z-index:5; } .JCLRgrip .JColResizer{position:absolute;background-color:red;filter:alpha(opacity=1);opacity:0;width:10px;height:100%;cursor: e-resize;top:0px} .JCLRLastGrip{position:absolute; width:1px; } .JCLRgripDrag{ border-left:1px dotted black;	} .JCLRFlex{width:auto!important;}</style>");
 
 	
 	/**
@@ -53,6 +53,10 @@
 		var	id = t.id = t.attr(ID) || SIGNATURE+count++;	//its id is obtained, if null new one is generated		
 		t.p = t.opt.postbackSafe; 							//short-cut to detect postback safe 		
 		if(!t.is("table") || tables[id] && !t.opt.partialRefresh) return; 		//if the object is not a table or if it was already processed then it is ignored.
+		t.originalColumnWidths = [];
+		$.each($('th', t), function () {
+		    t.originalColumnWidths.push($(this).width());
+		});
 		t.addClass(SIGNATURE).attr(ID, id).before('<div class="JCLRgrips"/>');	//the grips container object is added. Signature class forces table rendering in fixed-layout mode to prevent column's min-width
 		t.g = []; t.c = []; t.w = t.width(); t.gc = t.prev(); t.f=t.opt.fixed;	//t.c and t.g are arrays of columns and grips respectively				
 		if(options.marginLeft) t.gc.css("marginLeft", options.marginLeft);  	//if the table contains margins, it must be specified
@@ -100,7 +104,8 @@
             }
             g.bind('touchstart mousedown', onGripMouseDown); //bind the mousedown event to start dragging 
 
-			g.t = t; g.i = i; g.c = c;	c.w =c.width();		//some values are stored in the grip's node data
+			g.t = t; g.i = i; g.c = c;		//some values are stored in the grip's node data
+			c.w = (t.opt && t.opt.keepOriginalColumnWidths) ? t.originalColumnWidths[i] : c.width();
 			t.g.push(g); t.c.push(c);						//the current grip and column are added to its table object
 			c.width(c.w).removeAttr("width");				//the width of the column is converted into pixel-based measurements
 			g.data(SIGNATURE, {i:i, t:t.attr(ID), last: i == t.ln-1});	 //grip index and its table name are stored in the HTML 												
@@ -352,7 +357,7 @@
 				marginRight: null, 				//in case the table contains any margins, colResizable needs to know the values used, e.g. "10%", "15em", "5px" ...
 				disable: false,					//disables all the enhancements performed in a previously colResized table	
 				partialRefresh: false,			//can be used in combination with postbackSafe when the table is inside of an updatePanel
-				
+				keepOriginalColumnWidths: false,   //preserve original col widths in case they are not all the same
 				//events:
 				onDrag: null, 					//callback function to be fired during the column resizing process if liveDrag is enabled
 				onResize: null					//callback function fired when the dragging process is over


### PR DESCRIPTION
Hi,

the plug-in computes and assigns on each column the same width.
For our project we needed the ability to keep the original column widths.
I have added a new option called 'keepOriginalColumnWidths', which gives that ability.
By default the option is disabled.

Also, the plugin was forcefully clearing the header cells padding, i removed that css rule.

Thanks