### PR TITLE
Add files via upload

### DIFF
--- a/colResizable-1.6.js
+++ b/colResizable-1.6.js
@@ -118,8 +118,8 @@
 		}); 	
 		t.cg.removeAttr("width");	//remove the width attribute from elements in the colgroup 
 
-		t.find('td, th').not(th).not('table th, table td').each(function(){  
-			$(this).removeAttr('width');	//the width attribute is removed from all table cells which are not nested in other tables and dont belong to the header
+		t.find('td').not('table th').each(function () {
+			this.children[0].style.maxWidth = th[$(this).index()].style.width;
 		});		
         if(!t.f){
             t.removeAttr('width').addClass(FLEX); //if not fixed, let the table grow as needed

--- a/colResizable-1.6.js
+++ b/colResizable-1.6.js
@@ -13,6 +13,8 @@
 	
 	If you are going to use this plug-in in production environments it is 
 	strongly recommended to use its minified version: colResizable.min.js
+	
+	This version modified by Aaron Pesce(pull request pending)
 
 */
 


### PR DESCRIPTION
Fixes cells with large amounts of text in them from dictating column width, instead matching the header's current width. This part is necessary for the initial setup, and can be combined with an onDrag event functioning in a similar manner to ensure that the rules are maintained after resizing. #58 